### PR TITLE
Add widget configuration parameters

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -92,3 +92,6 @@ catalog:
     #   target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
     #   rules:
     #     - allow: [User, Group]
+
+customForm:
+  countriesUrl: https://restcountries.com/v3.1/all

--- a/plugins/custom-form-example-plugin/config.d.ts
+++ b/plugins/custom-form-example-plugin/config.d.ts
@@ -1,0 +1,11 @@
+export interface Config {
+  /**
+   * @visibility frontend
+   */
+  customForm?: {
+    /**
+     * @visibility frontend
+     */
+    countriesUrl?: string;
+  };
+}

--- a/plugins/custom-form-example-plugin/package.json
+++ b/plugins/custom-form-example-plugin/package.json
@@ -58,6 +58,8 @@
   },
   "files": [
     "dist",
-    "dist-scalprum"
-  ]
+    "dist-scalprum",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/plugins/custom-form-example-plugin/src/plugin.ts
+++ b/plugins/custom-form-example-plugin/src/plugin.ts
@@ -1,4 +1,9 @@
-import { createApiFactory, createPlugin } from '@backstage/core-plugin-api';
+import {
+  configApiRef,
+  createApiFactory,
+  createPlugin,
+  fetchApiRef,
+} from '@backstage/core-plugin-api';
 
 import { rootRouteRef } from './routes';
 import CustomApi from './customApi';
@@ -6,9 +11,9 @@ import { orchestratorFormApiRef } from '@janus-idp/backstage-plugin-orchestrator
 
 export const formApiFactory = createApiFactory({
   api: orchestratorFormApiRef,
-  deps: {},
-  factory() {
-    return new CustomApi();
+  deps: { configApi: configApiRef, fetchApi: fetchApiRef },
+  factory(options) {
+    return new CustomApi(options);
   },
 });
 

--- a/plugins/custom-form-example-plugin/src/widgets/CountryWidget.tsx
+++ b/plugins/custom-form-example-plugin/src/widgets/CountryWidget.tsx
@@ -3,22 +3,31 @@ import { MenuItem, FormControl, InputLabel, Select } from '@material-ui/core';
 import { Widget } from '@rjsf/utils';
 import { JSONSchema7 } from 'json-schema';
 import { JsonObject } from '@backstage/types';
+import { FormContextData } from '../types';
+
 // Define types for country and city options
 interface Option {
   label: string;
   value: string;
 }
+
 // Material-UI v4 Country Widget with Types
-const CountryWidget: Widget<JsonObject, JSONSchema7, any> = ({
+const CountryWidget: Widget<JsonObject, JSONSchema7, FormContextData> = ({
   value,
   onChange,
+  countriesUrl,
 }) => {
   const [countries, setCountries] = useState<Option[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const fetchCountries = async () => {
+  const fetchCountries = async (countriesUrl?: string) => {
+    if (!countriesUrl) {
+      return;
+    }
+
     try {
-      const response = await fetch('https://restcountries.com/v3.1/all');
+      // TODO: use Backstage fetchApi instead
+      const response = await fetch(countriesUrl);
       const data = (await response.json()) as unknown as any[];
       const countryOptions: Option[] = data
         .map((country: any) => ({
@@ -31,7 +40,7 @@ const CountryWidget: Widget<JsonObject, JSONSchema7, any> = ({
       setCountries(countryOptions);
     } catch (err) {
       // eslint-disable-next-line no-alert
-      alert('Failed to fetch contries');
+      alert(`Failed to fetch countries from: ${countriesUrl}`);
       // eslint-disable-next-line no-console
       console.error(err);
     } finally {
@@ -39,8 +48,8 @@ const CountryWidget: Widget<JsonObject, JSONSchema7, any> = ({
     }
   };
   useEffect(() => {
-    fetchCountries();
-  }, []);
+    fetchCountries(countriesUrl);
+  }, [countriesUrl]);
 
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     onChange(event.target.value as string);

--- a/plugins/custom-form-example-plugin/src/widgets/LanguageSelectWidget.tsx
+++ b/plugins/custom-form-example-plugin/src/widgets/LanguageSelectWidget.tsx
@@ -14,13 +14,16 @@ const LanguageWidget: Widget<JsonObject, JSONSchema7, FormContextData> = ({
   value,
   onChange,
   formContext,
+  countriesUrl,
 }) => {
   const [languages, setLanguages] = useState<Option[]>([]);
   const [loading, setLoading] = useState(false);
   const country = formContext?.country;
+
   const fetchLanguages = React.useCallback(async () => {
     try {
-      const response = await fetch('https://restcountries.com/v3.1/all');
+      // TODO: use Backstage fetchApi instead
+      const response = await fetch(countriesUrl);
       const data = (await response.json()) as unknown as any[];
       const countryData = data.find((c: any) => c.name.common === country);
       if (countryData && countryData.languages) {
@@ -40,7 +43,7 @@ const LanguageWidget: Widget<JsonObject, JSONSchema7, FormContextData> = ({
     } finally {
       setLoading(false);
     }
-  }, [country]);
+  }, [country, countriesUrl]);
 
   useEffect(() => {
     if (country) {


### PR DESCRIPTION
With this change, the widtgets can be configuraed via app-config.yaml.

The example config option includes in the app-config.yaml:
```
customForm:
  countriesUrl: https://restcountries.com/v3.1/all
```

But this can be extended for secrets passed via env variables as well.